### PR TITLE
Customizable refresh rates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.3.6
+
+### Added
+- Refresh rate for panel (to delay repaint after successive track focus changes) at properties. Higher values for 'Panel Selection Refresh Rate' may be set to avoid lag while scrolling the library.
+
+<br />
+
 # v1.3.5
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -5,5 +5,5 @@
   "id": "{BA9557CE-7B4B-4E0E-9373-99F511E81252}",
   "name": "Biography",
   "shouldGrabFocus": true,
-  "version": "1.3.5"
+  "version": "1.3.6"
 }

--- a/scripts/panel.js
+++ b/scripts/panel.js
@@ -192,21 +192,21 @@ class Panel {
 		this.focusLoad = $.debounce(() => {
 			if (!ppt.img_only) txt.on_playback_new_track();
 			if (!ppt.text_only || ui.style.isBlur || ppt.showFilmStrip) img.on_playback_new_track();
-		}, 250, {
+		}, ppt.focusLoadRate, {
 			'leading': true,
 			'trailing': true
 		});
 
 		this.focusServer = $.debounce(() => {
 			this.changed();
-		}, 5000, {
+		}, ppt.focusServerRate, {
 			'leading': true,
 			'trailing': true
 		});
 
 		this.lookUpServer = $.debounce(() => {
 			this.callServer(false, panel.id.focus, 'bio_lookUpItem', 0);
-		}, 1500);
+		}, ppt.lookUpServerRate);
 
 		if (!this.style.free || !$.isArray(this.style.free)) {
 			ppt.set('SYSTEM.Freestyle Custom BackUp', ppt.styleFree);

--- a/scripts/properties.js
+++ b/scripts/properties.js
@@ -276,6 +276,10 @@ let properties = [
 	['Overlay Strength (%)', 84.5, 'overlayStrength'],
 	['Overlay Type', 0, 'typeOverlay'],
 	['Panel Active', true, 'panelActive'],
+	
+	['Panel Selection Refresh Rate', 250, 'focusLoadRate'],
+	['Panel Focus Refresh Rate', 5000, 'focusServerRate'],
+	['Panel Lookup Refresh Rate', 1500, 'lookUpServerRate'],
 
 	['Photo Border [Dual Mode]', false, 'artBorderDual'],
 	['Photo Border [Image Only]', false, 'artBorderImgOnly'],

--- a/scripts/properties.js
+++ b/scripts/properties.js
@@ -447,14 +447,15 @@ if (ppt.get('Remove Old Properties', true)) {
 }
 
 [
-	{key: 'focusLoadRate', descr: 'Panel Selection Refresh Rate', min: 200, max: 3000},
-	{key: 'focusServerRate', descr: 'Panel Focus Refresh Rate', min: 5000, max: 15000},
-	{key: 'lookUpServerRate', descr: 'Panel Lookup Refresh Rate', min: 1500, max: 15000}
+	{key: 'focusLoadRate', descr: 'Panel Selection Refresh Rate', min: 200, max: 3000, oldDef: 250, newDef: 250},
+	{key: 'focusServerRate', descr: 'Panel Focus Refresh Rate', min: 5000, max: 15000, oldDef: 5000, newDef: 5000},
+	{key: 'lookUpServerRate', descr: 'Panel Lookup Refresh Rate', min: 1500, max: 15000, oldDef: 1500, newDef: 1500}
 ].forEach((rate) => {
 	const name = `${rate.descr} ${rate.min}-${rate.max} msec (Max)`;
 	const value = ppt.get(name, null);
 	if (value === null) {throw ('property_name: ' + name + '\nPanel\'s rate property name does not match range checked');}
 	else {
+		if (ppt[rate.key] === rate.oldDef && ppt[rate.key] !== rate.newDef) {ppt[rate.key] = rate.newDef;}
 		ppt[rate.key] = $.clamp(ppt[rate.key], rate.min, rate.max);
 		if (ppt[rate.key] !== Number(value)) {
 			ppt.set(name, ppt[rate.key]);

--- a/scripts/properties.js
+++ b/scripts/properties.js
@@ -277,9 +277,9 @@ let properties = [
 	['Overlay Type', 0, 'typeOverlay'],
 	['Panel Active', true, 'panelActive'],
 	
-	['Panel Selection Refresh Rate', 250, 'focusLoadRate'],
-	['Panel Focus Refresh Rate', 5000, 'focusServerRate'],
-	['Panel Lookup Refresh Rate', 1500, 'lookUpServerRate'],
+	['Panel Selection Refresh Rate 200-3000 msec (Max)', 250, 'focusLoadRate'],
+	['Panel Focus Refresh Rate 5000-15000 msec (Max)', 5000, 'focusServerRate'],
+	['Panel Lookup Refresh Rate 1500-15000 msec (Max)', 1500, 'lookUpServerRate'],
 
 	['Photo Border [Dual Mode]', false, 'artBorderDual'],
 	['Photo Border [Image Only]', false, 'artBorderImgOnly'],
@@ -445,3 +445,19 @@ if (ppt.get('Remove Old Properties', true)) {
 	oldProperties.forEach(v => window.SetProperty(v, null));
 	ppt.set('Remove Old Properties', false);
 }
+
+[
+	{key: 'focusLoadRate', descr: 'Panel Selection Refresh Rate', min: 200, max: 3000},
+	{key: 'focusServerRate', descr: 'Panel Focus Refresh Rate', min: 5000, max: 15000},
+	{key: 'lookUpServerRate', descr: 'Panel Lookup Refresh Rate', min: 1500, max: 15000}
+].forEach((rate) => {
+	const name = `${rate.descr} ${rate.min}-${rate.max} msec (Max)`;
+	const value = ppt.get(name, null);
+	if (value === null) {throw ('property_name: ' + name + '\nPanel\'s rate property name does not match range checked');}
+	else {
+		ppt[rate.key] = $.clamp(ppt[rate.key], rate.min, rate.max);
+		if (ppt[rate.key] !== Number(value)) {
+			ppt.set(name, ppt[rate.key]);
+		}
+	}
+});


### PR DESCRIPTION
Refresh rate for panel (to delay repaint after successive track focus changes) at properties. 
Higher values for 'Panel Selection Refresh Rate' may be set to avoid lag while scrolling the library.

250 ms for focusLoad was too low on my system while I was selecting different tracks on my library and I was always wondering why I had so much lag using the album list panel... this fixes it. Had not bothered adding the HTML counterpart, since I don't use the HTML options panel though (so I could not test it).