### PR TITLE
Clear interval after timeout

### DIFF
--- a/scripts/allmusic.js
+++ b/scripts/allmusic.js
@@ -39,6 +39,7 @@ function send({method = 'GET', URL, body = void(0), func = null, requestHeader =
 		xmlhttp.Send(method === 'POST' ? body : void(0));
 		// Add a timer for timeout
 		const timer = setTimeout(() => {
+			clearInterval(checkResponse);
 			try {
 				xmlhttp.WaitForResponse(-1);
 				onStateChange.call(xmlhttp, resolve, reject, func);


### PR DESCRIPTION
Fix response check interval not being cleared in case web request never settled, which results in foobar2000 using ~100% processor in such cases. It only happened on network errors.

That line was supposed to be on the sample I wrote you (at least I have it on my files), but maybe you missed the edit or was my mistake.