### PR TITLE
Dots on paths not working due to cleanup function

### DIFF
--- a/scripts/panel.js
+++ b/scripts/panel.js
@@ -395,11 +395,15 @@ class Panel {
 		if (!pth.endsWith('\\')) pth += '\\';
 
 		const c_pos = pth.indexOf(':');
+		const dotPathRegEx = /([/\\]).((?:foobar2000|fb2k)[^/\\]*|cache|local)([/\\])/g;
+		const bDotPath = dotPathRegEx.test(pth);
 		pth = type != 'lyr' ? 
 			pth.replace(/[/|:]/g, '-').replace(/\*/g, 'x').replace(/"/g, "''").replace(/[<>]/g, '_').replace(/\?/g, '').replace(/\\\./g, '\\_').replace(/\.+\\/, '\\').replace(/\s*\\\s*/g, '\\') :
 			pth.replace(/[/|:*"<>?]/g, '_');
 		if (c_pos < 3 && c_pos != -1) pth = $.replaceAt(pth, c_pos, ':');
-
+		if (bDotPath) { // Allow some special folders with dots
+			pth = pth.replace(dotPathRegEx, (_, p1, p2, p3) => p1 + '.' + p2 + p3);
+		}
 		while (pth.includes('\\\\')) pth = pth.replace(/\\\\/g, '\\_\\');
 		if (UNC) pth = `\\\\${pth}`;
 		return pth.trim();


### PR DESCRIPTION
Dots on paths not working due to cleanup function. Now allow some common folder names like .local, .cache, .foobar2000* or .fb2k* for Unix support.